### PR TITLE
[Client] Related MainPage / NavBar / Search Function + Rendering

### DIFF
--- a/mysurpin-client/src/App.scss
+++ b/mysurpin-client/src/App.scss
@@ -138,6 +138,12 @@ li {
     }
     .newlists__lists {
       padding: 48px;
+      display: flex;
+      flex-wrap: wrap;
+      overflow: scroll;
+    }
+    .newlists__list {
+      margin-bottom: 16px;
     }
   }
 }

--- a/mysurpin-client/src/components/MainSection.js
+++ b/mysurpin-client/src/components/MainSection.js
@@ -1,23 +1,17 @@
 import React, { useState } from "react";
-import { useHistory } from "react-router-dom";
-import { useDispatch } from "react-redux";
-import { searchTagLists } from "../actions/index";
 
 const MainSection = () => {
-  const dispatch = useDispatch();
-  const history = useHistory();
-
   const [tag, setTag] = useState("");
   const onChangeSearchTag = (e) => {
     setTag(e.target.value);
   };
-
+  // 미 구현 (시작)
   const handleSearchTag = () => {
     const payload = JSON.stringify({
       pagenumber: 1,
       tag: tag,
     });
-    return fetch(`http://localhost:4000/surpin/searchlists`, {
+    fetch(`http://localhost:4000/surpin/searchlists`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -25,20 +19,14 @@ const MainSection = () => {
       },
       body: payload,
     })
-      .then((res) => res.json())
       .then((res) => {
         console.log(res);
-        if (res.status === 500) {
-          history.push("/searchpage");
-        } else if (res.status === 200) {
-          dispatch(searchTagLists(res.json()));
-          history.push("/searchpage");
-        } else {
-          alert("오류 발생!");
-        }
+        return res;
       })
-      .catch((err) => console.error(err));
+      .then((res) => res.json())
+      .then((data) => console.log(data.message));
   };
+  // 미구현 (끝)
 
   return (
     <div className="mainSection">

--- a/mysurpin-client/src/components/Navbar.js
+++ b/mysurpin-client/src/components/Navbar.js
@@ -1,17 +1,63 @@
-import React from "react";
-import { useSelector } from "react-redux";
+import React, { useState } from "react";
+import { useSelector, useDispatch } from "react-redux";
 import { Link } from "react-router-dom";
 import { useHistory } from "react-router-dom";
+import { searchTagLists } from "../actions/index";
+
+// fakeData 나중에 꼭 지우기 (여기부터)
+import { fakeData } from "../reducers/initialState";
+// fakeData 나중에 꼭 지우기 (여기까지)
 
 const Navbar = () => {
   const userState = useSelector((state) => state.userReducer);
   const {
     user: { token, nickname },
   } = userState;
+  // const searchTagState = useSelector((state) => state.surpinReducer);
+  // const { searchTagLists } = searchTagState;
+
+  const [tag, setTag] = useState("");
   const history = useHistory();
+  const dispatch = useDispatch();
 
   const handleMySurpinBtn = () => {
     history.push(`/surpinlists/${nickname}`);
+  };
+
+  const onChangeSearchTag = (e) => {
+    setTag(e.target.value);
+  };
+
+  // 확인용 추후에 지워야 함 (시작) -- fakeData === 서버에 태그검색 결과 요청 initialState.searchTagLists
+  // const handleSearchBtn = () => {
+  //   dispatch(searchTagLists(fakeData));
+  // };
+  // 지워야 함 (끝)
+
+  // 요청 함수만 구현 작동 안됨 ㅠㅠ
+  const handleSearchBtn = () => {
+    const payload = JSON.stringify({
+      pagenumber: 1,
+      tag: tag,
+    });
+    fetch(`http://localhost:4000/surpin/searchlists`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        credentials: "include",
+      },
+      body: payload,
+    })
+      .then((res) => res.json())
+      .then((body) => {
+        if (body.message) {
+          console.log(body);
+          dispatch(searchTagLists(body));
+        } else {
+          alert("Bad Request");
+        }
+      })
+      .catch((err) => console.error(err));
   };
 
   return (
@@ -27,9 +73,16 @@ const Navbar = () => {
         <div className="hidden"></div>
       ) : (
         <div className="navbar__searchbar">
-          <input className="navbar__searchbar__input"></input>
+          <input
+            className="navbar__searchbar__input"
+            onChange={onChangeSearchTag}
+            value={tag}
+          ></input>
           <Link to="/searchpage">
-            <button className="navbar__searchbar__btn">
+            <button
+              className="navbar__searchbar__btn"
+              onClick={handleSearchBtn}
+            >
               <img src="../../public/images/loupe.png" alt="" />
             </button>
           </Link>

--- a/mysurpin-client/src/components/NewListsSection.js
+++ b/mysurpin-client/src/components/NewListsSection.js
@@ -8,70 +8,23 @@ const NewListsSection = () => {
 
   console.log("newLists의 상태", newLists);
   console.log("newLists.surpins", newLists.surpins);
-  let fakeSurpin = [
-    {
-      surpinId: 1,
-      title: "첫번째 서핀리스트",
-      desc: "beDev",
-      writer: "제원",
-      thumbnail:
-        "https://ca.slack-edge.com/TR5603XSB-U01GVG58R5W-00ded8765867-512",
-      created_At: "21-03-10 12:00:00",
-      modified_At: "21-03-10 12:00:00",
-      tags: ["다들", "힘내세요"],
-    },
-    {
-      surpinId: 2,
-      title: "두번째 서핀리스트",
-      desc: "beDev",
-      writer: "윤택",
-      thumbnail:
-        "https://ca.slack-edge.com/TR5603XSB-U01GVG58R5W-00ded8765867-512",
-      created_At: "21-03-10 12:00:00",
-      modified_At: "21-03-10 12:00:00",
-      tags: ["다들", "힘내세요"],
-    },
-    {
-      surpinId: 3,
-      title: "세번째 서핀리스트",
-      desc: "beDev",
-      writer: "주혜",
-      thumbnail:
-        "https://ca.slack-edge.com/TR5603XSB-U01GVG58R5W-00ded8765867-512",
-      created_At: "21-03-10 12:00:00",
-      modified_At: "21-03-10 12:00:00",
-      tags: ["다들", "힘내세요"],
-    },
-    {
-      surpinId: 4,
-      title: "네번째 서핀리스트",
-      desc: "beDev",
-      writer: "유빈",
-      thumbnail:
-        "https://ca.slack-edge.com/TR5603XSB-U01GVG58R5W-00ded8765867-512",
-      created_At: "21-03-10 12:00:00",
-      modified_At: "21-03-10 12:00:00",
-      tags: ["다들", "힘내세요"],
-    },
-  ];
+
+  // 추후에 새 리스트가 없을 경우 페이지 만들기
   return (
     <div className="newListsSection">
       <div className="newlists__title">New Surpins</div>
       <ul className="newlists__lists">
-        {fakeSurpin.map((surpin) => {
-          return (
-            <li className="newlists__list">
-              <Surpin surpin={surpin}></Surpin>
-            </li>
-          );
-        })}
-        {/* {newLists.surpins.map((surpin) => {
-          return (
-            <li className="newlists__list">
-              <Surpin surpin={surpin}></Surpin>
-            </li>
-          );
-        })} */}
+        {!newLists.surpins || newLists.surpins.length === 0 ? (
+          <li className="newlists__list">Loading...</li>
+        ) : (
+          newLists.surpins.map((surpin) => {
+            return (
+              <li className="newlists__list" key={surpin.surpinId}>
+                <Surpin surpin={surpin} key={surpin.surpinId}></Surpin>
+              </li>
+            );
+          })
+        )}
       </ul>
     </div>
   );

--- a/mysurpin-client/src/components/SearchResult.js
+++ b/mysurpin-client/src/components/SearchResult.js
@@ -1,15 +1,15 @@
 import React from "react";
 
-const SearchResult = (props) => {
-  const { name, description, urlsCount, createdAt, modifiedAt } = props;
+const SearchResult = ({ surpin }) => {
+  const { title, desc, created_At, modified_At } = surpin;
 
   return (
     <div className="searchResult">
-      <div className="searchResult__name">{name}MySurpin</div>
-      <div className="searchResult__description">{description}꿀팁모음</div>
-      <div className="searchResult__urlsCount">{urlsCount}54</div>
-      <div className="searchResult__createdAt">{createdAt}2021-03-18</div>
-      <div className="searchResult__updatedAt">{modifiedAt}</div>
+      <div className="searchResult__name">{title}</div>
+      <div className="searchResult__description">{desc}</div>
+      <div className="searchResult__urlsCount">{"생각 중"}</div>
+      <div className="searchResult__createdAt">{created_At}</div>
+      <div className="searchResult__updatedAt">{modified_At}</div>
     </div>
   );
 };

--- a/mysurpin-client/src/components/Surpin.js
+++ b/mysurpin-client/src/components/Surpin.js
@@ -15,7 +15,7 @@ const Surpin = ({ surpin }) => {
   } = surpin;
 
   return (
-    <Link to={`/surpinmodal/${surpinId}`}>
+    <Link to={{ pathname: `/surpinmodal/${surpinId}`, surpin }}>
       <div className="surpin">
         <div className="surpin__content">
           <img
@@ -26,11 +26,13 @@ const Surpin = ({ surpin }) => {
           <div className="surpin-title">{title}</div>
           <div className="surpin-username">{writer}</div>
           <ul className="list__tags">
-            <li className="list__tag">{tags}#태그</li>
-            <li className="list__tag">{tags}#블로깅</li>
-            <li className="list__tag">{tags}#추천</li>
-            <li className="list__tag">{tags}#추천</li>
-            <li className="list__tag">{tags}#코드스테이츠</li>
+            {tags.map((tag, idx) => {
+              return (
+                <li className="list__tag" key={idx}>
+                  {tag}
+                </li>
+              );
+            })}
           </ul>
         </div>
       </div>

--- a/mysurpin-client/src/pages/MainPage.js
+++ b/mysurpin-client/src/pages/MainPage.js
@@ -8,6 +8,10 @@ import ScrollBtn from "../components/ScrollBtn";
 import { getBestTags, getNewLists } from "../actions/index";
 import { useSelector, useDispatch } from "react-redux";
 
+// fakeData 나중에 꼭 지우기 (여기부터)
+import { fakeData } from "../reducers/initialState";
+// fakeData 나중에 꼭 지우기 (여기까지)
+
 const MainPage = () => {
   const mainPageState = useSelector((state) => state.surpinReducer);
   console.log(mainPageState);
@@ -23,20 +27,28 @@ const MainPage = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  // 본래 사용해야 하는 함수 + 추후에 api 요청 주소 변경
+  // useEffect(() => {
+  //   console.log("=== useEffect, NewLists ===");
+  //   fetch(`http://localhost:4000/surpin/newlists`, {
+  //     method: "POST",
+  //     headers: {
+  //       "Content-Type": "application/json",
+  //       credentials: "include",
+  //     },
+  //   })
+  //     .then((res) => res.json())
+  //     .then((data) => dispatch(getNewLists(data)))
+  //     .catch((err) => console.log(err));
+  //   // eslint-disable-next-line react-hooks/exhaustive-deps
+  // }, []);
+
+  // 나중에 꼭 지우기 (여기부터)
   useEffect(() => {
-    console.log("=== useEffect, NewLists ===");
-    fetch(`http://localhost:4000/surpin/newlists`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        credentials: "include",
-      },
-    })
-      .then((res) => res.json())
-      .then((data) => dispatch(getNewLists(data)))
-      .catch((err) => console.log(err));
+    dispatch(getNewLists(fakeData));
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+  // 나중에 꼭 지우기 (여기까지)
 
   console.log("newLists의 상태", newLists);
   console.log("tags의 상태", tags);

--- a/mysurpin-client/src/pages/SearchPage.js
+++ b/mysurpin-client/src/pages/SearchPage.js
@@ -3,44 +3,36 @@ import React from "react";
 import Navbar from "../components/Navbar";
 import Surpin from "../components/Surpin";
 import SearchResult from "../components/SearchResult";
-// import { useSelector, useDispatch } from "react-redux";
+import { useSelector } from "react-redux";
 
 const SearchPage = () => {
-  // const searchTagState = useSelector((state) => state.searchReducer);
-  // const { searchTagLists } = searchTagState;
-  // console.log(searchTagState);
+  const searchTagState = useSelector((state) => state.surpinReducer);
+  const { searchTagLists } = searchTagState;
+  console.log(searchTagLists);
 
   return (
     <>
       <Navbar></Navbar>
       <div className="searchPage">
         <div className="searchbar">
-          <input className="sarchbar__input" placeholder="search for"></input>
-          <button className="sarchbar__button">
+          <input className="searchbar__input" placeholder="search for"></input>
+          <button className="searchbar__button">
             <img src="../../public/images/search.png"></img>
           </button>
         </div>
         <div className="searchpage-best-results">
           <div className="searchpage__best__title">Best Surpins</div>
           <ul className="searchpage-best-lists">
-            <li className="searchpage-best-list">
-              <Surpin></Surpin>
-            </li>
-            <li className="searchpage-best-list">
-              <Surpin></Surpin>
-            </li>
-            <li className="searchpage-best-list">
-              <Surpin></Surpin>
-            </li>
-            <li className="searchpage-best-list">
-              <Surpin></Surpin>
-            </li>
-            <li className="searchpage-best-list">
-              <Surpin></Surpin>
-            </li>
-            <li className="searchpage-best-list">
-              <Surpin></Surpin>
-            </li>
+            {searchTagLists.top.map((searchTagList) => {
+              return (
+                <li
+                  className="searchpage-best-list"
+                  key={searchTagList.surpinId}
+                >
+                  <Surpin surpin={searchTagList}></Surpin>
+                </li>
+              );
+            })}
           </ul>
         </div>
         <div className="searchpage-all-results">
@@ -53,21 +45,16 @@ const SearchPage = () => {
               <div className="topbar__createdAt">생성일</div>
             </div>
             <ul className="searchpage-all-results__lists">
-              <li className="searchpage-all-result__list">
-                <SearchResult></SearchResult>
-              </li>
-              <li className="searchpage-all-result__list">
-                <SearchResult></SearchResult>
-              </li>
-              <li className="searchpage-all-result__list">
-                <SearchResult></SearchResult>
-              </li>
-              <li className="searchpage-all-result__list">
-                <SearchResult></SearchResult>
-              </li>
-              <li className="searchpage-all-result__list">
-                <SearchResult></SearchResult>
-              </li>
+              {searchTagLists.surpins.map((surpin) => {
+                return (
+                  <li
+                    className="searchpage-all-result__list"
+                    key={surpin.surpinId}
+                  >
+                    <SearchResult surpin={surpin}></SearchResult>
+                  </li>
+                );
+              })}
             </ul>
           </div>
         </div>

--- a/mysurpin-client/src/reducers/index.js
+++ b/mysurpin-client/src/reducers/index.js
@@ -2,13 +2,11 @@ import { combineReducers } from "redux";
 import userReducer from "./userReducer";
 import surpinReducer from "./surpinReducer";
 import tagsReducer from "./tagsReducer";
-import searchReducer from "./searchReducer";
 
 const rootReducer = combineReducers({
   userReducer,
   surpinReducer,
   tagsReducer,
-  searchReducer,
 });
 
 export default rootReducer;

--- a/mysurpin-client/src/reducers/initialState.js
+++ b/mysurpin-client/src/reducers/initialState.js
@@ -4,11 +4,199 @@ export const initialState = {
     email: "guest",
     nickname: "guest",
   },
+  // MainPage-NewLists
   newLists: {},
+  // MainPage-BestTags
   tags: [],
-  showSurpin: null,
-  showUserLists: null,
-  showUserTags: null,
+  showSurpin: {},
+  showUserLists: {},
+  showUserTags: {},
+  // MainPage & NavBar SearchTagsLists
   searchTagLists: {},
   mainPage: {},
+};
+
+export const fakeData = {
+  surpinCount: 1,
+  surpinCountPerPage: 10,
+  surpins: [
+    {
+      surpinId: 1,
+      title: "첫번째 서핀리스트",
+      desc: "beDev",
+      writer: "제원",
+      thumbnail:
+        "https://ca.slack-edge.com/TR5603XSB-U01GVG58R5W-00ded8765867-512",
+      created_At: "21-03-10 12:00:00",
+      modified_At: "21-03-10 12:00:00",
+      tags: ["다들", "힘내세요", 1],
+    },
+    {
+      surpinId: 2,
+      title: "두번째 서핀리스트",
+      desc: "beDev",
+      writer: "윤택",
+      thumbnail:
+        "https://ca.slack-edge.com/TR5603XSB-U01GVG58R5W-00ded8765867-512",
+      created_At: "21-03-10 12:00:00",
+      modified_At: "21-03-10 12:00:00",
+      tags: ["다들", "힘내세요", 2],
+    },
+    {
+      surpinId: 3,
+      title: "세번째 서핀리스트",
+      desc: "beDev",
+      writer: "주혜",
+      thumbnail:
+        "https://ca.slack-edge.com/TR5603XSB-U01GVG58R5W-00ded8765867-512",
+      created_At: "21-03-10 12:00:00",
+      modified_At: "21-03-10 12:00:00",
+      tags: ["다들", "힘내세요", 3],
+    },
+    {
+      surpinId: 4,
+      title: "네번째 서핀리스트",
+      desc: "beDev",
+      writer: "유빈",
+      thumbnail:
+        "https://ca.slack-edge.com/TR5603XSB-U01GVG58R5W-00ded8765867-512",
+      created_At: "21-03-10 12:00:00",
+      modified_At: "21-03-10 12:00:00",
+      tags: ["다들", "힘내세요", 4],
+    },
+    {
+      surpinId: 5,
+      title: "다섯번째 서핀리스트",
+      desc: "beDev",
+      writer: "제원",
+      thumbnail:
+        "https://ca.slack-edge.com/TR5603XSB-U01GVG58R5W-00ded8765867-512",
+      created_At: "21-03-10 12:00:00",
+      modified_At: "21-03-10 12:00:00",
+      tags: ["다들", "힘내세요", 5],
+    },
+    {
+      surpinId: 6,
+      title: "여섯번째 서핀리스트",
+      desc: "beDev",
+      writer: "윤택",
+      thumbnail:
+        "https://ca.slack-edge.com/TR5603XSB-U01GVG58R5W-00ded8765867-512",
+      created_At: "21-03-10 12:00:00",
+      modified_At: "21-03-10 12:00:00",
+      tags: ["다들", "힘내세요", 6],
+    },
+    {
+      surpinId: 7,
+      title: "일곱번째 서핀리스트",
+      desc: "beDev",
+      writer: "주혜",
+      thumbnail:
+        "https://ca.slack-edge.com/TR5603XSB-U01GVG58R5W-00ded8765867-512",
+      created_At: "21-03-10 12:00:00",
+      modified_At: "21-03-10 12:00:00",
+      tags: ["다들", "힘내세요", 7],
+    },
+    {
+      surpinId: 8,
+      title: "여덟번째 서핀리스트",
+      desc: "beDev",
+      writer: "유빈",
+      thumbnail:
+        "https://ca.slack-edge.com/TR5603XSB-U01GVG58R5W-00ded8765867-512",
+      created_At: "21-03-10 12:00:00",
+      modified_At: "21-03-10 12:00:00",
+      tags: ["다들", "힘내세요", 8],
+    },
+  ],
+  top: [
+    {
+      surpinId: 6,
+      title: "여섯번째 서핀리스트",
+      desc: "beDev",
+      writer: "윤택",
+      thumbnail:
+        "https://ca.slack-edge.com/TR5603XSB-U01GVG58R5W-00ded8765867-512",
+      created_At: "21-03-10 12:00:00",
+      modified_At: "21-03-10 12:00:00",
+      tags: ["다들", "힘내세요", 6],
+    },
+    {
+      surpinId: 1,
+      title: "첫번째 서핀리스트",
+      desc: "beDev",
+      writer: "제원",
+      thumbnail:
+        "https://ca.slack-edge.com/TR5603XSB-U01GVG58R5W-00ded8765867-512",
+      created_At: "21-03-10 12:00:00",
+      modified_At: "21-03-10 12:00:00",
+      tags: ["다들", "힘내세요", 1],
+    },
+    {
+      surpinId: 2,
+      title: "두번째 서핀리스트",
+      desc: "beDev",
+      writer: "윤택",
+      thumbnail:
+        "https://ca.slack-edge.com/TR5603XSB-U01GVG58R5W-00ded8765867-512",
+      created_At: "21-03-10 12:00:00",
+      modified_At: "21-03-10 12:00:00",
+      tags: ["다들", "힘내세요", 2],
+    },
+    {
+      surpinId: 3,
+      title: "세번째 서핀리스트",
+      desc: "beDev",
+      writer: "주혜",
+      thumbnail:
+        "https://ca.slack-edge.com/TR5603XSB-U01GVG58R5W-00ded8765867-512",
+      created_At: "21-03-10 12:00:00",
+      modified_At: "21-03-10 12:00:00",
+      tags: ["다들", "힘내세요", 3],
+    },
+    {
+      surpinId: 8,
+      title: "여덟번째 서핀리스트",
+      desc: "beDev",
+      writer: "유빈",
+      thumbnail:
+        "https://ca.slack-edge.com/TR5603XSB-U01GVG58R5W-00ded8765867-512",
+      created_At: "21-03-10 12:00:00",
+      modified_At: "21-03-10 12:00:00",
+      tags: ["다들", "힘내세요", 8],
+    },
+    {
+      surpinId: 4,
+      title: "네번째 서핀리스트",
+      desc: "beDev",
+      writer: "유빈",
+      thumbnail:
+        "https://ca.slack-edge.com/TR5603XSB-U01GVG58R5W-00ded8765867-512",
+      created_At: "21-03-10 12:00:00",
+      modified_At: "21-03-10 12:00:00",
+      tags: ["다들", "힘내세요", 4],
+    },
+    {
+      surpinId: 5,
+      title: "다섯번째 서핀리스트",
+      desc: "beDev",
+      writer: "제원",
+      thumbnail:
+        "https://ca.slack-edge.com/TR5603XSB-U01GVG58R5W-00ded8765867-512",
+      created_At: "21-03-10 12:00:00",
+      modified_At: "21-03-10 12:00:00",
+      tags: ["다들", "힘내세요", 5],
+    },
+    {
+      surpinId: 7,
+      title: "일곱번째 서핀리스트",
+      desc: "beDev",
+      writer: "주혜",
+      thumbnail:
+        "https://ca.slack-edge.com/TR5603XSB-U01GVG58R5W-00ded8765867-512",
+      created_At: "21-03-10 12:00:00",
+      modified_At: "21-03-10 12:00:00",
+      tags: ["다들", "힘내세요", 7],
+    },
+  ],
 };

--- a/mysurpin-client/src/reducers/surpinReducer.js
+++ b/mysurpin-client/src/reducers/surpinReducer.js
@@ -3,6 +3,7 @@ import {
   GET_BEST_TAGS,
   SHOW_USER_LISTS,
   SHOW_SURPIN,
+  SEARCH_TAG_LISTS,
 } from "../actions/index";
 import { initialState } from "./initialState";
 
@@ -28,6 +29,10 @@ const surpinReducer = (state = initialState, action) => {
         showSurpin: "서버에서 받아온 값",
       });
 
+    case SEARCH_TAG_LISTS:
+      return Object.assign({}, state, {
+        searchTagLists: action.payload.data,
+      });
     default:
       return state;
   }


### PR DESCRIPTION
## 공통 : fakeData 사용 시 기능 구현 가능

### 1. MainPage
페이지 자체에서 newLists, bestTags 요청 useEffect => store(리덕스) 저장

- MainSection - 검색요청 함수 구현 but 응답 처리 X
- NewListsSection - store에서 정보를 가져온 후, 렌더링
- BestTagsSection - store에서 정보를 가져온 후, 렌더링

### 2. NavBar
- 실제 요청 함수 구현 but fakeData 사용 중
- 버튼 클릭 시 서버에 태그 검색 요청 => store(리덕스) 저장 => searchPage 이동

### 3. Search 관련
- SearchPage - , NavBar에서 저장한 store 값을 가져와 렌더링 , 페이지 내 검색 기능 구현 X
- Surpin, SearchResult - SearchPage에서 props를 받아 렌더링이 가능하도록 수정