### PR TITLE
[Client] Issue/Editmode state, Search Page redirect

### DIFF
--- a/mysurpin-client/src/App.scss
+++ b/mysurpin-client/src/App.scss
@@ -92,16 +92,20 @@ li {
       display: flex;
       align-items: center;
       margin-right: 8px;
-      background-color: $medium;
       width: 300px;
       height: 28px;
       padding: 4px 10px;
       border-radius: 3px;
       transition: 1s all ease;
-      background-color: rgba(238, 238, 238, 0.1);
+      background-color: rgba(238, 238, 238, 0.4);
+
       input {
         width: 80%;
         margin-left: 20px;
+        color: $dark;
+        &::placeholder {
+          color: $dark;
+        }
       }
       img {
         height: 22px;
@@ -1479,17 +1483,24 @@ li {
   font-size: 0.85rem;
 
   .urlList__urlName {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
     color: rgba(255, 255, 255, 0.7);
     font-family: "Poppin";
     font-weight: 700;
     width: 40%;
     text-overflow: ellipsis;
+    margin-right: 1rem;
   }
   .urlList__url {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
     color: rgba(255, 255, 255, 0.7);
     font-family: "Poppin";
     font-weight: 400;
-    width: 40%;
+    width: 45%;
     text-overflow: ellipsis;
   }
 }

--- a/mysurpin-client/src/aws_controller/aws_controller.js
+++ b/mysurpin-client/src/aws_controller/aws_controller.js
@@ -185,7 +185,7 @@ const uploadSurpinThumbnail = async (email, files) => {
     const filename = await getNextFileIndex(email);
 
     const savedFileLocation = await uploadFile(email, files, filename);
-    return `http://${bucketName}/${savedFileLocation}`;
+    return `https://${bucketName}/${savedFileLocation}`;
   } catch (err) {
     return -2;
   }

--- a/mysurpin-client/src/components/BesttagsSection.js
+++ b/mysurpin-client/src/components/BesttagsSection.js
@@ -61,9 +61,13 @@ const BesttagsSection = ({ animatedItem, chartdata, chartlabel }) => {
       })
       .then((res) => res.json())
       .then((body) => {
-        dispatch(getTagLists({ ...body, label }));
-        history.push("/searchpage");
+        dispatch(getTagLists(body));
+        history.push({
+          pathname: "/searchpage",
+          state: { searchTag: label },
+        });
       })
+
       .catch((err) => console.error(err));
   };
 

--- a/mysurpin-client/src/components/MainSection.js
+++ b/mysurpin-client/src/components/MainSection.js
@@ -57,7 +57,10 @@ const MainSection = () => {
           setAlertModalOpen(true);
         } else if (body.message === "No surpin with request tag") {
           dispatch(getTagLists({}));
-          history.push("/searchpage");
+          history.push({
+            pathname: "/searchpage",
+            state: { searchTag: tag },
+          });
         } else {
           dispatch(getTagLists({ ...body, tag }));
           history.push("/searchpage");

--- a/mysurpin-client/src/components/Navbar.js
+++ b/mysurpin-client/src/components/Navbar.js
@@ -91,10 +91,12 @@ const Navbar = ({ navBarState, isSignPage = "" }) => {
           setAlertModalOpen(true);
           setAlertModalComment("검색어를 입력하세요.");
         } else if (body.message === "No surpin with request tag") {
-          dispatch(getTagLists({}));
-          history.push("/searchpage");
+          history.push({
+            pathname: "/searchpage",
+            state: { searchTag: tag },
+          });
         } else {
-          dispatch(getTagLists({ ...body, tag }));
+          dispatch(getTagLists({ ...body, label: tag }));
           history.push("/searchpage");
         }
       })

--- a/mysurpin-client/src/pages/EditUserInfo.js
+++ b/mysurpin-client/src/pages/EditUserInfo.js
@@ -7,7 +7,7 @@ import useCheckToken from "../hooks/useCheckToken";
 import AlertModal from "../components/AlertModal";
 
 const EditUserInfo = () => {
-  const [editState, setEditState] = useState(false);
+  const [editState, setEditState] = useState(true);
   const [alertModalOpen, setAlertModalOpen] = useState(false);
   const [alertModalComment, setAlertModalComment] = useState("");
 

--- a/mysurpin-client/src/pages/SearchPage.js
+++ b/mysurpin-client/src/pages/SearchPage.js
@@ -7,6 +7,7 @@ import { useSelector, useDispatch } from "react-redux";
 import { getTagLists } from "../actions/index";
 import useScrollEventListener from "../hooks/useScrollEventListener";
 import AlertModal from "../components/AlertModal";
+import { useLocation } from "react-router-dom";
 require("dotenv").config();
 
 const SearchPage = () => {
@@ -20,6 +21,16 @@ const SearchPage = () => {
   const [mergedData, setMergedData] = useState(searchTagLists.surpins);
   const [alertModalOpen, setAlertModalOpen] = useState(false);
   const [alertModalComment, setAlertModalComment] = useState("");
+  const [propsTag, setPropsTag] = useState(undefined);
+
+  const location = useLocation();
+  useEffect(() => {
+    if (!newTag) {
+      setPropsTag(location.state.searchTag);
+    } else {
+      setPropsTag(undefined);
+    }
+  }, [newTag, propsTag]);
 
   const closeModal = useCallback(() => {
     setAlertModalOpen(false);
@@ -97,6 +108,7 @@ const SearchPage = () => {
           dispatch(getTagLists(data));
           setNewTag(tag);
           setNewSurpinCount(data.surpinCount);
+          setTag("");
         });
     }
   }, [tag, pagenumber]);
@@ -124,8 +136,8 @@ const SearchPage = () => {
         </div>
         <div className="searchpage-best-results">
           <div className="searchpage-result-title">
-            ' {searchTagLists.label || newTag} ' 에 대한 {newSurpinCount} 건의
-            검색결과
+            ' {propsTag || newTag} ' 에 대한 {newSurpinCount || 0}
+            건의 검색결과
           </div>
           <div className="searchpage__best__title">Popular Surpins</div>
           <ul className="searchpage-best-lists">


### PR DESCRIPTION
- editmode일 때 내 서핀에 저장하기 안보이게 수정
- 로그인 안되어있을 때 edit이 안되게 수정
- Modal 창 뒤로가기 버튼 redirect path 수정
- 삭제했을 때 검색페이지로 넘어가도록 수정
- 내 서핀'에' 추가 → 내 서핀'으로' 추가
- navbar 어둡게 수정
- navbar에서도 잘 넘어가게 수정
- 메인에서 검색 시 tag 없을 때 0건으로 수정